### PR TITLE
Bugfix/memory leak in bls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache/
 
 # Translations
 *.mo

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 What's new in cuvarbase
 ***********************
-
+* **0.2.1**
+	* Added ``__call__`` support for ``ConditionalEntropyAsyncProcess`` and ``LombScargleAsyncProcess``.
 * **0.2.0**
 	* Many more unit tests for BLS and CE.
 	* BLS

--- a/cuvarbase/__init__.py
+++ b/cuvarbase/__init__.py
@@ -1,2 +1,18 @@
-import pycuda.autoinit
+#import pycuda.autoinit 
+__all__ = ['bls', 'ce', 'core', 'cunfft', 'lombscargle', 'pdm', 'utils']
 __version__ = "0.2.0"
+
+import atexit
+import pycuda.tools
+import pycuda.driver as cuda
+
+def _cleanup_cuda():
+	#print("CLEANING CONTEXTS")
+	while cuda.Context.get_current() is not None:
+		#print(" --> FOUND ONE <--")
+		cuda.Context.pop()
+		#print("     [cleaned]")
+
+	pycuda.tools.clear_context_caches()
+
+atexit.register(_cleanup_cuda)

--- a/cuvarbase/bls.py
+++ b/cuvarbase/bls.py
@@ -15,12 +15,16 @@ import pycuda.autoinit
 import pycuda.driver as cuda
 import pycuda.gpuarray as gpuarray
 from pycuda.compiler import SourceModule
+from pycuda.tools import make_default_context
 
 from .core import GPUAsyncProcess
 from .utils import find_kernel, _module_reader
 
 import resource
 import numpy as np
+import atexit
+
+cuda.init()
 
 _default_block_size = 256
 _all_function_names = ['full_bls_no_sol',

--- a/cuvarbase/bls.py
+++ b/cuvarbase/bls.py
@@ -264,32 +264,26 @@ class BLSMemory(object):
         self.bls = cuda.aligned_zeros(shape=(nfreqs,),
                                       dtype=self.rtype,
                                       alignment=resource.getpagesize())
-        self.bls = cuda.register_host_memory(self.bls)
 
         self.nbins0 = cuda.aligned_zeros(shape=(nfreqs,),
                                          dtype=np.int32,
                                          alignment=resource.getpagesize())
-        self.nbins0 = cuda.register_host_memory(self.nbins0)
 
         self.nbinsf = cuda.aligned_zeros(shape=(nfreqs,),
                                          dtype=np.int32,
-                                         alignment=resource.getpagesize())
-        self.nbinsf = cuda.register_host_memory(self.nbinsf)
+                                         alignment=resource.getpagesize()) 
 
         self.t = cuda.aligned_zeros(shape=(ndata,),
                                     dtype=self.rtype,
                                     alignment=resource.getpagesize())
-        self.t = cuda.register_host_memory(self.t)
 
         self.yw = cuda.aligned_zeros(shape=(ndata,),
                                      dtype=self.rtype,
                                      alignment=resource.getpagesize())
-        self.yw = cuda.register_host_memory(self.yw)
 
         self.w = cuda.aligned_zeros(shape=(ndata,),
                                     dtype=self.rtype,
                                     alignment=resource.getpagesize())
-        self.w = cuda.register_host_memory(self.w)
 
     def allocate_freqs(self, nfreqs=None):
         if nfreqs is None:
@@ -542,7 +536,7 @@ def eebls_gpu_fast(t, y, dy, freqs, qmin=1e-2, qmax=0.5,
         memory.transfer_data_to_cpu()
         if stream is not None:
             stream.synchronize()
-
+     
     return memory.bls
 
 

--- a/cuvarbase/core.py
+++ b/cuvarbase/core.py
@@ -7,15 +7,33 @@ from builtins import object
 import numpy as np
 from .utils import gaussian_window, tophat_window, get_autofreqs
 import pycuda.driver as cuda
+import pycuda.tools as cutools
 from pycuda.compiler import SourceModule
-
+from functools import wraps
+cuda.init()
 
 class GPUAsyncProcess(object):
+    _runfuncs = ['run']
     def __init__(self, *args, **kwargs):
+
+        # initialize cuda
+        cuda.init()
+
         self.reader = kwargs.get('reader', None)
         self.nstreams = kwargs.get('nstreams', None)
         self.function_kwargs = kwargs.get('function_kwargs', {})
-        self.device = kwargs.get('device', 0)
+        self.context = kwargs.get('context', cuda.Context.get_current())
+
+        if self.context is None:
+            self.context = cutools.make_default_context()
+
+        self.device = kwargs.get('device', self.context.get_device())
+        if isinstance(self.device, int):
+            self.device = cuda.Device(self.device)
+
+        assert(isinstance(self.device, cuda.Device))
+        assert(self.context.get_device() == self.device)
+        
         self.memory = kwargs.get('memory', None)
         self.streams = []
         self.gpu_data = []
@@ -35,10 +53,30 @@ class GPUAsyncProcess(object):
     def run(self, *args, **kwargs):
         raise NotImplementedError()
 
-    def finish(self):
-        """ synchronize all active streams """
+    def synchronize_streams(self):
         for i, stream in enumerate(self.streams):
             stream.synchronize()
+
+    def finish(self):
+        """ synchronize all active streams """
+
+        for stream in self.streams:
+            stream.synchronize()
+
+        return self
+
+    def set_context(self, context):
+        """
+        Set the GPU context of this object.
+        """
+
+        if hasattr(self, 'context') and self.context is not None:
+            self.scrub()
+        
+        self.context = context
+        self.device = self.context.get_device()
+
+        return self
 
     def batched_run(self, data, batch_size=10, **kwargs):
         """ Run your data in batches (avoids memory problems) """
@@ -66,9 +104,51 @@ class GPUAsyncProcess(object):
         if use_constant_freqs and hasattr(self, 'batched_run_const_nfreq'):
             assert(freqs is None or not is_list_of_lists(freqs))
 
-            return self.batched_run_const_nfreq(data, freqs=freqs, batch_size=batch_size, **kwargs)
+            return self.batched_run_const_nfreq(data,
+                                                freqs=freqs,
+                                                batch_size=batch_size,
+                                                **kwargs)
 
         elif len(data) > batch_size or (self.memory is not None and len(data) > len(self.memory)):
             return self.batched_run(data, freqs=freqs, batch_size=batch_size, **kwargs)
 
         return self.run(data, freqs=freqs, batch_size=batch_size, **kwargs)
+
+
+def push_context_hook_for(cls, target_function):
+
+    @wraps(target_function)
+    def hooked(s, *args, **kwargs):
+        if not hasattr(s, 'context') or s.context is None:
+            if hasattr(s, 'device') and s.device is not None:
+                s.context = s.device.make_context()
+            else:
+                s.context = cutools.make_default_context()
+                s.device = s.context.get_device()
+
+        if s.context != cuda.Context.get_current():
+            s.context.push()
+
+        return target_function(s, *args, **kwargs)
+
+    return hooked
+
+def pop_context_hook_for(cls, target_function):
+
+    @wraps(target_function)
+    def hooked(s, *args, **kwargs):
+        rval = target_function(s, *args, **kwargs)
+        s.context.pop()
+        return rval
+    return hooked
+
+
+def for_all_runfuncs(decorator):
+    def wrapper(cls):
+        for func_name in cls._runfuncs:
+            setattr(cls, func_name, decorator(cls, getattr(cls, func_name)))
+        return cls
+    return wrapper
+
+ensure_context_push = for_all_runfuncs(push_context_hook_for)
+ensure_context_pop = for_all_runfuncs(pop_context_hook_for)

--- a/cuvarbase/cunfft.py
+++ b/cuvarbase/cunfft.py
@@ -16,7 +16,7 @@ from pycuda.compiler import SourceModule
 
 import skcuda.fft as cufft
 
-from .core import GPUAsyncProcess
+from .core import GPUAsyncProcess, ensure_context_push
 from .utils import find_kernel, _module_reader
 
 
@@ -309,6 +309,8 @@ def nfft_adjoint_async(memory, functions,
     return memory.ghat_c
 
 
+
+@ensure_context_push
 class NFFTAsyncProcess(GPUAsyncProcess):
     """
     `GPUAsyncProcess` for the adjoint NFFT.
@@ -346,7 +348,10 @@ class NFFTAsyncProcess(GPUAsyncProcess):
     >>> nfft_adjoint = proc.run(data)
 
     """
-
+    _runfuncs = ['run',
+                 'batched_run',
+                 '_compile_and_prepare_functions',
+                 'allocate']
     def __init__(self, *args, **kwargs):
         super(NFFTAsyncProcess, self).__init__(*args, **kwargs)
 
@@ -375,6 +380,7 @@ class NFFTAsyncProcess(GPUAsyncProcess):
                                'normalize']
 
         self.allocated_memory = []
+
 
     def m_from_C(self, C, sigma):
         """ 

--- a/cuvarbase/lombscargle.py
+++ b/cuvarbase/lombscargle.py
@@ -1091,6 +1091,8 @@ class LombScargleAsyncProcess(GPUAsyncProcess):
 
         return [(freqs, lsp) for lsp in lsps]
 
+    
+
 
 def fap_baluev(t, dy, z, fmax, d_K=3, d_H=1, use_gamma=True):
     """

--- a/cuvarbase/pdm.py
+++ b/cuvarbase/pdm.py
@@ -14,7 +14,7 @@ import pycuda.gpuarray as gpuarray
 from pycuda.compiler import SourceModule
 # import pycuda.autoinit
 
-from .core import GPUAsyncProcess
+from .core import GPUAsyncProcess, ensure_context_push
 from .utils import weights, find_kernel
 
 
@@ -128,6 +128,7 @@ def pdm_async(stream, data_cpu, data_gpu, pow_cpu, function,
     return pow_cpu
 
 
+@ensure_context_push
 class PDMAsyncProcess(GPUAsyncProcess):
 
     def __init__(self, *args, **kwargs):

--- a/cuvarbase/tests/test_ce.py
+++ b/cuvarbase/tests/test_ce.py
@@ -63,7 +63,66 @@ class TestCE(object):
             sing_results.extend(proc.run([d], freqs=freqs))
             proc.finish()
 
+        print(sing_results)
         for rb, rnb in zip(mult_results, sing_results):
+            fb, pb = rb
+            fnb, pnb = rnb
+
+            print(fb)
+            print(fnb)
+
+            assert(not any(np.isnan(pb)))
+            assert(not any(np.isnan(pnb)))
+
+            assert_allclose(pnb, pb, rtol=lsrtol, atol=lsatol)
+            assert_allclose(fnb, fb, rtol=lsrtol, atol=lsatol)
+
+    @pytest.mark.parametrize('ndatas', [1, 7])
+    @pytest.mark.parametrize('batch_size', [1, 3])
+    @pytest.mark.parametrize('use_double', [True, False])
+    @pytest.mark.parametrize('use_fast,weighted,shmem_lc,freq_batch_size',
+                             [(True, False, False, 1),
+                              (True, False, True, None),
+                              (False, True, False, None),
+                              (False, False, False, None)])
+    @pytest.mark.parametrize('phase_bins,phase_overlap',
+                             [(10, 1)])
+    @pytest.mark.parametrize('mag_bins,mag_overlap',
+                             [(5, 0)])
+    def test_call(self, ndatas, batch_size, use_double,
+                  mag_bins, phase_bins, mag_overlap,
+                  phase_overlap, use_fast,
+                  shmem_lc, weighted,
+                  freq_batch_size):
+
+        datas = [data(ndata=rand.randint(50, 100))
+                 for i in range(ndatas)]
+        kwargs = dict(use_double=use_double,
+                      mag_bins=mag_bins,
+                      phase_bins=phase_bins,
+                      phase_overlap=phase_overlap,
+                      mag_overlap=mag_overlap,
+                      use_fast=use_fast,
+                      weighted=weighted)
+        proc = ConditionalEntropyAsyncProcess(**kwargs)
+        df = 0.02
+        max_freq = 1.1
+        min_freq = 0.9
+        nf = int((max_freq - min_freq) / df)
+        freqs = min_freq + df * np.arange(nf)
+
+        run_kw = dict(shmem_lc=shmem_lc, freqs=freqs,
+                      freq_batch_size=freq_batch_size)
+        batched_results = proc(datas, **run_kw)
+        proc.finish()
+
+        non_batched_results = []
+        for d in datas:
+            r = proc([d], freqs=freqs)
+            proc.finish()
+            non_batched_results.extend(r)
+
+        for rb, rnb in zip(batched_results, non_batched_results):
             fb, pb = rb
             fnb, pnb = rnb
 
@@ -72,6 +131,7 @@ class TestCE(object):
 
             assert_allclose(pnb, pb, rtol=lsrtol, atol=lsatol)
             assert_allclose(fnb, fb, rtol=lsrtol, atol=lsatol)
+
 
     @pytest.mark.parametrize('ndatas', [1, 7])
     @pytest.mark.parametrize('batch_size', [1, 3])

--- a/cuvarbase/tests/test_ce.py
+++ b/cuvarbase/tests/test_ce.py
@@ -234,7 +234,7 @@ class TestCE(object):
                 assert(min(r_all) == r_best)
 
 
-    @pytest.mark.parametrize('ndatas', [1, 7])
+    @pytest.mark.parametrize('ndatas', [1, 6, 7])
     @pytest.mark.parametrize('batch_size', [1, 3])
     @pytest.mark.parametrize('use_double', [True, False])
     @pytest.mark.parametrize('use_fast,weighted,shmem_lc,freq_batch_size',
@@ -274,12 +274,10 @@ class TestCE(object):
         batched_results = proc.batched_run_const_nfreq(datas, **run_kw)
         proc.finish()
 
-        procnb = ConditionalEntropyAsyncProcess(**kwargs)
-
         non_batched_results = []
         for d, (frq, p) in zip(datas, batched_results):
-            r = procnb.run([d], **run_kw)
-            procnb.finish()
+            r = proc.run([d], **run_kw)
+            proc.finish()
             non_batched_results.extend(r)
 
         for f0, (fb, pb), (fnb, pnb) in zip(frequencies, batched_results,

--- a/cuvarbase/tests/test_lombscargle.py
+++ b/cuvarbase/tests/test_lombscargle.py
@@ -13,7 +13,8 @@ from astropy.stats.lombscargle import LombScargle
 
 from ..lombscargle import LombScargleAsyncProcess
 from pycuda.tools import mark_cuda_test
-import pycuda.autoinit
+#import pycuda.autoinit
+
 spp = 3
 nfac = 3
 lsrtol = 1E-2
@@ -147,8 +148,10 @@ class TestLombScargle(object):
                                  samples_per_peak=spp,
                                  use_fft=False,
                                  python_dir_sums=True)
-        ls_proc.finish()
+        
         fgpu_reg, pgpu_reg = result_reg[0]
+
+        ls_proc.finish()
 
         assert_similar(pgpu_reg, pgpu_ds)
 
@@ -166,6 +169,8 @@ class TestLombScargle(object):
             sing_results.extend(ls_proc.run([d], nyquist_factor=nfac,
                                 samples_per_peak=spp))
             ls_proc.finish()
+
+        ls_proc.finish()
 
         for rb, rnb in zip(mult_results, sing_results):
             fb, pb = rb
@@ -195,12 +200,16 @@ class TestLombScargle(object):
             ls_proc.finish()
             non_batched_results.extend(r)
 
+        
+        ls_proc.finish()
+
         for rb, rnb in zip(batched_results, non_batched_results):
             fb, pb = rb
             fnb, pnb = rnb
 
             assert_allclose(pnb, pb, rtol=lsrtol, atol=lsatol)
             assert_allclose(fnb, fb, rtol=lsrtol, atol=lsatol)
+
 
     def test_batched_run_const_nfreq(self, make_plot=False, ndatas=27,
                                      batch_size=5, sigma=nfft_sigma,
@@ -229,6 +238,7 @@ class TestLombScargle(object):
             ls_procnb.finish()
             non_batched_results.extend(r)
 
+        ls_procnb.finish()
         # for f0, (fb, pb), (fnb, pnb) in zip(frequencies, batched_results,
         #                                    non_batched_results):
         #    print f0, fb[np.argmax(pb)], fnb[np.argmax(pnb)]

--- a/docs/source/plots/benchmarks.py
+++ b/docs/source/plots/benchmarks.py
@@ -154,22 +154,21 @@ def time_group(task_dict, group_func, values):
     return times
 
 n0 = 1000
-ndatas = np.floor(np.logspace(1, 4, num=8)).astype(np.int)
+ndatas = np.floor(np.logspace(1, 4.5, num=8)).astype(np.int)
 #nblocks = np.arange(1, 25)
 #nblocks = np.concatenate((nblocks, np.arange(nblocks[-1], 3000, 50)))
 nblocks = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 50, 100, 200, 500, 1000, 2000, 5000]
 freq_batch_sizes = [1, 5, 10, 50, 100, 500, 1000, 2000, 5000]
 
-t, y, dy = data(max(ndatas), baseline=5. * 365)
-#freqs_t, qvals_t = bls.transit_autofreq(t, **_eebls_defaults)
+t, y, dy = data(max(ndatas), baseline=10. * 365)
+freqs_t, qvals_t = bls.transit_autofreq(t, fmin=0.01, **_eebls_defaults)
 t0, y0, dy0 = subset_data(t, y, dy, n0)
 
-#qmin = min(qvals_t)
-#qmax = max(qvals_t)
-#print(qmin, qmax)
+qmin = min(qvals_t)
+qmax = max(qvals_t)
 freqs = get_freqs(baseline=(max(t) - min(t)), samples_per_peak=4, fmin=0.01)
 
-print(len(freqs))
+print(qmin, qmax, len(freqs_t), len(freqs))
 # profile_cuvarbase_ce(t0, y0, dy0, freqs=freqs, use_fast=True, force_nblocks=200) 
 
 


### PR DESCRIPTION
This removes calls to `pycuda.driver.register_host_memory` from `BLSMemory.allocate_pinned_arrays`. It seems this is the source of the memory leak problems, and in real-world tests it doesn't seem to make a measurable difference in speed.