### PR TITLE
fix memory leak in BLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 *,cover
+.pytest_cache/
 
 # Translations
 *.mo

--- a/cuvarbase/bls.py
+++ b/cuvarbase/bls.py
@@ -260,32 +260,26 @@ class BLSMemory(object):
         self.bls = cuda.aligned_zeros(shape=(nfreqs,),
                                       dtype=self.rtype,
                                       alignment=resource.getpagesize())
-        self.bls = cuda.register_host_memory(self.bls)
 
         self.nbins0 = cuda.aligned_zeros(shape=(nfreqs,),
                                          dtype=np.int32,
                                          alignment=resource.getpagesize())
-        self.nbins0 = cuda.register_host_memory(self.nbins0)
 
         self.nbinsf = cuda.aligned_zeros(shape=(nfreqs,),
                                          dtype=np.int32,
                                          alignment=resource.getpagesize())
-        self.nbinsf = cuda.register_host_memory(self.nbinsf)
 
         self.t = cuda.aligned_zeros(shape=(ndata,),
                                     dtype=self.rtype,
                                     alignment=resource.getpagesize())
-        self.t = cuda.register_host_memory(self.t)
 
         self.yw = cuda.aligned_zeros(shape=(ndata,),
                                      dtype=self.rtype,
                                      alignment=resource.getpagesize())
-        self.yw = cuda.register_host_memory(self.yw)
 
         self.w = cuda.aligned_zeros(shape=(ndata,),
                                     dtype=self.rtype,
                                     alignment=resource.getpagesize())
-        self.w = cuda.register_host_memory(self.w)
 
     def allocate_freqs(self, nfreqs=None):
         if nfreqs is None:


### PR DESCRIPTION
Addresses https://github.com/johnh2o2/cuvarbase/issues/4

It seems the memory leak in BLS has to do with `register_host_memory` calls in `BLSMemory.allocate_pinned_arrays`. I've removed these calls since they seem to make no measurable difference in speed.

All pytest tests pass on my local machine.