### PR TITLE
Fix astropy lombscargle import and remove pytest.fixture decorators

### DIFF
--- a/cuvarbase/tests/test_bls.py
+++ b/cuvarbase/tests/test_bls.py
@@ -64,7 +64,6 @@ def plot_bls_sol(t, y, dy, freq, q, phi0):
     plt.show()
 
 
-@pytest.fixture
 def data(seed=100, sigma=0.1, ybar=12., snr=10, ndata=200, freq=10.,
          q=0.01, phi0=None, baseline=1.):
 

--- a/cuvarbase/tests/test_ce.py
+++ b/cuvarbase/tests/test_ce.py
@@ -17,7 +17,6 @@ seed = 100
 rand = np.random.RandomState(seed)
 
 
-@pytest.fixture
 def data(sigma=0.1, ndata=500, freq=3., snr=1000, t0=0.):
 
     t = np.sort(rand.rand(ndata)) + t0

--- a/cuvarbase/tests/test_lombscargle.py
+++ b/cuvarbase/tests/test_lombscargle.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from numpy.testing import assert_allclose
-from astropy.stats.lombscargle import LombScargle
+from astropy.timeseries import LombScargle
 
 from ..lombscargle import LombScargleAsyncProcess
 from pycuda.tools import mark_cuda_test
@@ -23,7 +23,6 @@ nfft_sigma = 5
 rand = np.random.RandomState(100)
 
 
-@pytest.fixture
 def data(seed=100, sigma=0.1, ndata=100, freq=3.):
     t = np.sort(rand.rand(ndata))
     y = np.cos(2 * np.pi * freq * t)

--- a/cuvarbase/tests/test_nfft.py
+++ b/cuvarbase/tests/test_nfft.py
@@ -38,7 +38,6 @@ def scale_time(t, samples_per_peak):
     return (t - min(t)) / (samples_per_peak * (max(t) - min(t))) - 0.5
 
 
-@pytest.fixture
 def data(seed=100, sigma=0.1, ndata=100, samples_per_peak=spp):
 
     rand = np.random.RandomState(seed)


### PR DESCRIPTION
Minor fixes but necessary now that pytest will fail upon incorrect usage of their pytest.fixture decorator.

Full disclosure these unit tests were written by someone (myself) who is not super great at writing unit tests, so they definitely could be written better, and fixtures probably would make sense to use. However, I ended up just calling the "fixtures" from within test functions and that's not how they're supposed to be used!

