### PR TITLE
Add an option in BLS to ignore "inverted" solutions

### DIFF
--- a/cuvarbase/__init__.py
+++ b/cuvarbase/__init__.py
@@ -1,2 +1,6 @@
 import pycuda.autoinit
 __version__ = "0.2.4"
+
+
+def _easter_egg_for_kevin():
+    print('Hey Kevin! You are using the right branch :)')

--- a/cuvarbase/__init__.py
+++ b/cuvarbase/__init__.py
@@ -1,2 +1,2 @@
 import pycuda.autoinit
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/cuvarbase/__init__.py
+++ b/cuvarbase/__init__.py
@@ -1,2 +1,2 @@
 import pycuda.autoinit
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/cuvarbase/__init__.py
+++ b/cuvarbase/__init__.py
@@ -1,6 +1,3 @@
 import pycuda.autoinit
 __version__ = "0.2.4"
 
-
-def _easter_egg_for_kevin():
-    print('Hey Kevin! You are using the right branch :)')

--- a/cuvarbase/bls.py
+++ b/cuvarbase/bls.py
@@ -37,7 +37,7 @@ _function_signatures = {
                         np.intp, np.intp, np.intp,
                         np.intp, np.uint32, np.uint32,
                         np.uint32, np.uint32, np.uint32,
-                        np.float32, np.float32],
+                        np.float32, np.float32, np.uint32],
     'bin_and_phase_fold_custom': [np.intp, np.intp, np.intp,
                                   np.intp, np.intp, np.intp,
                                   np.intp, np.intp, np.int32,
@@ -56,7 +56,7 @@ _function_signatures = {
          np.intp, np.intp, np.uint32, np.uint32,
          np.uint32, np.uint32, np.uint32, np.uint32,
          np.float32, np.uint32],
-    'binned_bls_bst': [np.intp, np.intp, np.intp, np.uint32]
+    'binned_bls_bst': [np.intp, np.intp, np.intp, np.uint32, np.uint32]
 }
 
 
@@ -523,7 +523,7 @@ def eebls_gpu_fast(t, y, dy, freqs, qmin=1e-2, qmax=0.5,
                  np.uint32(i_freq))
         args += (np.uint32(max_nbins), np.uint32(noverlap))
         args += (np.float32(dlogq), np.float32(dphi))
-        args += (ignore_negative_delta_sols,)
+        args += (np.uint32(ignore_negative_delta_sols),)
 
         if stream is not None:
             func.prepared_async_call(*args, shared_size=int(mem_req))
@@ -704,7 +704,7 @@ def eebls_gpu_custom(t, y, dy, freqs, q_values, phi_values,
         args = (bls_grid, block, stream)
         args += (yw_g_bin.ptr, w_g_bin.ptr)
         args += (bls_tmp_g.ptr,  np.uint32(nf * nb))
-        args += (ignore_negative_delta_sols,)
+        args += (np.uint32(ignore_negative_delta_sols),)
         bls_func.prepared_async_call(*args)
 
         args = (max_func, bls_tmp_g, bls_tmp_sol_g)
@@ -937,7 +937,7 @@ def eebls_gpu(t, y, dy, freqs, qmin=1e-2, qmax=0.5,
         args = (bls_grid, block, stream)
         args += (yw_g_bin.ptr, w_g_bin.ptr)
         args += (bls_tmp_g.ptr,  np.int32(all_bins))
-        args += (ignore_negative_delta_sols,)
+        args += (np.uint32(ignore_negative_delta_sols),)
         bls_func.prepared_async_call(*args)
 
         args = (max_func, bls_tmp_g, bls_tmp_sol_g)

--- a/cuvarbase/kernels/bls.cu
+++ b/cuvarbase/kernels/bls.cu
@@ -17,7 +17,7 @@ __device__ float mod1(float a){
 	return a - floorf(a);
 }
 
-__device__ float bls_value(float ybar, float w, bool ignore_negative_delta_sols){
+__device__ float bls_value(float ybar, float w, unsigned int ignore_negative_delta_sols){
     // if ignore negative delta sols is turned on, that means only solutions where
     // the mean amplitude within the transit is _lower_ than the mean amplitude of the source 
     // are considered: it will ignore "inverted dips"

--- a/cuvarbase/kernels/bls.cu
+++ b/cuvarbase/kernels/bls.cu
@@ -17,15 +17,19 @@ __device__ float mod1(float a){
 	return a - floorf(a);
 }
 
-__device__ float bls_value(float ybar, float w){
-	return (w > 1e-10 && w < 1.f - 1e-10) ? ybar * ybar / (w * (1.f - w)) : 0.f;
+__device__ float bls_value(float ybar, float w, bool ignore_negative_delta_sols){
+    // if ignore negative delta sols is turned on, that means only solutions where
+    // the mean amplitude within the transit is _lower_ than the mean amplitude of the source 
+    // are considered: it will ignore "inverted dips"
+	float bls = (w > 1e-10 && w < 1.f - 1e-10) ? ybar * ybar / (w * (1.f - w)) : 0.f;
+    return (ignore_negative_delta_sols & (ybar > 0)) ? 0.f : bls;
 }
 
-__global__ void binned_bls_bst(float *yw, float *w, float *bls, unsigned int n){
+__global__ void binned_bls_bst(float *yw, float *w, float *bls, unsigned int n, bool ignore_negative_delta_sols){
 	unsigned int i = get_id();
 
 	if (i < n){
-		bls[i] = bls_value(yw[i], w[i]);
+		bls[i] = bls_value(yw[i], w[i], ignore_negative_delta_sols);
 	}
 }
 
@@ -179,7 +183,8 @@ __global__ void full_bls_no_sol(
 						unsigned int hist_size,
 						unsigned int noverlap,
 						float dlogq,
-						float dphi){
+						float dphi,
+                        bool ignore_negative_delta_sols){
 	unsigned int i = get_id();
 
 	extern __shared__ float sh[];
@@ -268,7 +273,7 @@ __global__ void full_bls_no_sol(
 				thread_w += block_bins[2 * (m % nbf) + 1];
 			}
 
-			bls1 = bls_value(thread_yw, thread_w);
+			bls1 = bls_value(thread_yw, thread_w, ignore_negative_delta_sols);
 			if (bls1 > thread_max_bls)
 				thread_max_bls = bls1;
 		}
@@ -287,7 +292,7 @@ __global__ void full_bls_no_sol(
 				}
 				m0 = m;
 
-				bls1 = bls_value(thread_yw, thread_w);
+				bls1 = bls_value(thread_yw, thread_w, ignore_negative_delta_sols);
 				if (bls1 > thread_max_bls)
 					thread_max_bls = bls1;
 			}

--- a/cuvarbase/kernels/bls.cu
+++ b/cuvarbase/kernels/bls.cu
@@ -22,10 +22,10 @@ __device__ float bls_value(float ybar, float w, bool ignore_negative_delta_sols)
     // the mean amplitude within the transit is _lower_ than the mean amplitude of the source 
     // are considered: it will ignore "inverted dips"
 	float bls = (w > 1e-10 && w < 1.f - 1e-10) ? ybar * ybar / (w * (1.f - w)) : 0.f;
-    return (ignore_negative_delta_sols & (ybar > 0)) ? 0.f : bls;
+    return ((ignore_negative_delta_sols == 1) & (ybar > 0)) ? 0.f : bls;
 }
 
-__global__ void binned_bls_bst(float *yw, float *w, float *bls, unsigned int n, bool ignore_negative_delta_sols){
+__global__ void binned_bls_bst(float *yw, float *w, float *bls, unsigned int n, unsigned int ignore_negative_delta_sols){
 	unsigned int i = get_id();
 
 	if (i < n){
@@ -184,7 +184,7 @@ __global__ void full_bls_no_sol(
 						unsigned int noverlap,
 						float dlogq,
 						float dphi,
-                        bool ignore_negative_delta_sols){
+                        unsigned int ignore_negative_delta_sols){
 	unsigned int i = get_id();
 
 	extern __shared__ float sh[];

--- a/cuvarbase/pdm.py
+++ b/cuvarbase/pdm.py
@@ -222,6 +222,7 @@ class PDMAsyncProcess(GPUAsyncProcess):
 
         # Prepare data
         for i,(t, y, w, freqs) in enumerate(data):
+            t, y, w, freqs = t.copy(), y.copy(), w.copy(), freqs.copy()
             t -= np.mean(t)
             y -= np.mean(y)
             data[i] = t, y, w, freqs

--- a/cuvarbase/tests/test_bls.py
+++ b/cuvarbase/tests/test_bls.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from builtins import zip
 from builtins import range
 from builtins import object
+from itertools import product 
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -65,7 +66,7 @@ def plot_bls_sol(t, y, dy, freq, q, phi0):
 
 
 def data(seed=100, sigma=0.1, ybar=12., snr=10, ndata=200, freq=10.,
-         q=0.01, phi0=None, baseline=1.):
+         q=0.01, phi0=None, baseline=1., negative_delta=False):
 
     rand = np.random.RandomState(seed)
 
@@ -73,6 +74,9 @@ def data(seed=100, sigma=0.1, ybar=12., snr=10, ndata=200, freq=10.,
         phi0 = rand.rand()
 
     delta = snr * sigma / np.sqrt(ndata * q * (1 - q))
+
+    if negative_delta:
+        delta *= -1
 
     model = transit_model(phi0, q, delta)
 
@@ -147,46 +151,52 @@ class TestBLS(object):
     rtol = 1e-3
     atol = 1e-5
 
-    @pytest.mark.parametrize("freq", [0.3])
-    @pytest.mark.parametrize("phi0", [0.5])
-    @pytest.mark.parametrize("dlogq", [0.2])
-    @pytest.mark.parametrize("ignore_negative_delta_sols", [True, False])
-    def test_ignore_positive_sols(self, freq, phi0, dlogq, ignore_negative_delta_sols):
-        q = q_transit(freq)
+    # TODO: tests that have specific bls values; test single_bls function returns
+    #       what you expect it to for several example problems
+    class SolutionParams(object):
+        def __init__(self, freq, phi0, q, baseline, ybar, snr, negative_delta):
+            self.freq = freq
+            self.phi0 = phi0
+            self.q = q
+            self.baseline = baseline
+            self.ybar = ybar
+            self.snr = snr
+            self.negative_delta = negative_delta
 
-        t, y, dy = data(snr=30, q=q, phi0=phi0, freq=freq, baseline=365.)
+    @pytest.mark.parametrize("args", [(
+            SolutionParams(freq=0.3, phi0=0.5, q=0.2, baseline=365., ybar=0., snr=50.,
+                           negative_delta=True),
+            {'bls0': 0.8902446483898836, 'bls_ignore': 0}
+        )
+    ])
+    def test_ignore_positive_sols(self, args):
+        solution, bls_values = args
+        t, y_neg, dy = data(snr=solution.snr,
+                            q=solution.q,
+                            phi0=solution.phi0,
+                            freq=solution.freq,
+                            baseline=solution.baseline,
+                            ybar=solution.ybar,
+                            negative_delta=solution.negative_delta)
+        
+        freq, q, phi0 = solution.freq, solution.q, solution.phi0
 
-        freqs, power, sols = eebls_transit_gpu(t, y, dy,
-                                               samples_per_peak=2,
-                                               freq_batch_size=1,
-                                               ignore_negative_delta_sols=ignore_negative_delta_sols,
-                                               nstreams=1,
-                                               dlogq=dlogq,
-                                               fmin=freq * 0.99,
-                                               fmax=freq * 1.01)
-        pcpu = [single_bls(t, y, dy, x[0], *x[1], ignore_negative_delta_sols=ignore_negative_delta_sols)
-                for x in zip(freqs, sols)]
-        pcpu = np.asarray(pcpu)
-
-
-        pows, diffs = list(zip(*sorted(zip(pcpu,
-                                           np.absolute(power - pcpu)),
-                                       key=lambda x: -x[1])))
-
-        upper_bound = self.rtol * np.array(pows) + self.atol
-        mostly_ok = sum(np.array(diffs) > upper_bound) / len(pows) < 1e-2
-        not_too_bad = max(diffs) < 1e-1
-
-        print(max(diffs))
-        assert mostly_ok and not_too_bad
+        bls_default = single_bls(t, y_neg, dy, freq, q, phi0)
+        bls0 = single_bls(t, y_neg, dy, freq, q, phi0, ignore_negative_delta_sols=False)
+        bls_ignore = single_bls(t, y_neg, dy, freq, q, phi0, 
+                                ignore_negative_delta_sols=True)
+        assert bls_values['bls0'] == bls0
+        assert bls_values['bls_ignore'] == bls_ignore
+        assert (bls0 == bls_default)
 
     @pytest.mark.parametrize("freq", [0.3])
     @pytest.mark.parametrize("phi0", [0.0, 0.5])
     @pytest.mark.parametrize("dlogq", [0.2, -1])
     @pytest.mark.parametrize("nstreams", [1, 3])
     @pytest.mark.parametrize("freq_batch_size", [1, 3, None])
+    @pytest.mark.parametrize("ignore_negative_delta_sols", [True, False])
     def test_transit_parameter_consistency(self, freq, phi0, dlogq, nstreams,
-                                           freq_batch_size):
+                                           freq_batch_size, ignore_negative_delta_sols):
         q = q_transit(freq)
 
         t, y, dy = data(snr=30, q=q, phi0=phi0, freq=freq, baseline=365.)
@@ -196,9 +206,10 @@ class TestBLS(object):
                                                freq_batch_size=freq_batch_size,
                                                nstreams=nstreams,
                                                dlogq=dlogq,
+                                               ignore_negative_delta_sols=ignore_negative_delta_sols,
                                                fmin=freq * 0.99,
                                                fmax=freq * 1.01)
-        pcpu = [single_bls(t, y, dy, x[0], *x[1])
+        pcpu = [single_bls(t, y, dy, x[0], *x[1], ignore_negative_delta_sols=ignore_negative_delta_sols)
                 for x in zip(freqs, sols)]
         pcpu = np.asarray(pcpu)
 
@@ -231,11 +242,13 @@ class TestBLS(object):
         assert mostly_ok and not_too_bad
 
     @pytest.mark.parametrize("freq", [1.0])
-    @pytest.mark.parametrize("phi_index", [0, 10, -1])
-    @pytest.mark.parametrize("q_index", [0, 5, -1])
+    @pytest.mark.parametrize("phi_index", [0, 10])
+    @pytest.mark.parametrize("q_index", [0, 5])
     @pytest.mark.parametrize("nstreams", [1, 3])
     @pytest.mark.parametrize("freq_batch_size", [1, 3, None])
-    def test_custom(self, freq, q_index, phi_index, freq_batch_size, nstreams):
+    @pytest.mark.parametrize("ignore_negative_delta_sols", [True, False])
+    def test_custom(self, freq, q_index, phi_index, freq_batch_size, nstreams,
+                    ignore_negative_delta_sols):
         q_values = np.logspace(-1.1, -0.8, num=10)
         phi_values = np.linspace(0, 1, int(np.ceil(2./min(q_values))))
 
@@ -243,82 +256,39 @@ class TestBLS(object):
         phi = phi_values[phi_index]
 
         t, y, dy = data(snr=10, q=q, phi0=phi, freq=freq,
-                        baseline=365.)
+                        baseline=365., ndata=500)
 
         df = min(q_values) / (10 * (max(t) - min(t)))
         freqs = np.linspace(freq - 10 * df, freq + 10 * df, 20)
 
         power, gsols = eebls_gpu_custom(t, y, dy, freqs,
                                         q_values, phi_values,
+                                        ignore_negative_delta_sols=ignore_negative_delta_sols,
                                         freq_batch_size=freq_batch_size,
                                         nstreams=nstreams)
 
-        # Now get CPU values
-        qgrid, phigrid = np.meshgrid(q_values, phi_values)
-        bls = np.vectorize(single_bls, excluded=set([0, 1, 2, 3]))
-
-        blses = []
-
-        max_bls = []
-        cpu_bls = []
-        sols = []
-        for freq, (qg, phg) in zip(freqs, gsols):
-            p = bls(t, y, dy, freq, qgrid, phigrid)
-            pc = single_bls(t, y, dy, freq, qg, phg)
-            mind = np.unravel_index(p.argmax(), p.shape)
-            qsol = qgrid[mind]
-            phisol = phigrid[mind]
-
-            max_bls.append(p[mind])
-            cpu_bls.append(pc)
-            sols.append((qsol, phisol))
-            blses.append(p)
-        qsg, phsg = list(zip(*gsols))
-        qs, phs = list(zip(*sols))
-        if self.plot:
-            import matplotlib.pyplot as plt
-            f, ax = plt.subplots()
-
-            ax.plot(freqs, max_bls)
-            ax.plot(freqs, power)
-
-            plt.show()
-
-            f, ax = plt.subplots()
-            ax.plot(freqs, qs)
-            ax.plot(freqs, qsg)
-
-            plt.show()
-
-            f, ax = plt.subplots()
-            ax.plot(freqs, phs)
-            ax.plot(freqs, phsg)
-
-            plt.show()
-
-        for bls_arr in [max_bls, cpu_bls]:
-            max_diffs = 0.5 * self.rtol * (bls_arr + power) + self.atol
-            diffs = np.absolute(bls_arr - power)
-            nbad = sum(diffs > max_diffs)
-
-            mostly_ok = nbad / float(len(power)) < 1e-2 or nbad == 1
-            not_too_bad = max(np.absolute(bls_arr - power) / power) < 1e-1
-
-            print(max(diffs) / max_diffs[np.argmax(max_diffs)])
-            if not (mostly_ok and not_too_bad):
-                print(nbad / float(len(power)), not_too_bad)
-                import matplotlib.pyplot as plt
-                plt.plot(freqs, power)
-                plt.plot(freqs, bls_arr)
-                plt.show()
-            assert(mostly_ok and not_too_bad)
+        for freq, (qg, phg), gpower in zip(freqs, gsols, power):
+            q_and_phis = product(q_values, phi_values)
+            
+            best_q, best_phi, best_p = None, None, None
+            for Q, PHI in q_and_phis:
+                p = single_bls(t, y, dy, freq, Q, PHI,
+                               ignore_negative_delta_sols=ignore_negative_delta_sols)
+                if best_p is None or p > best_p:
+                    best_p = p
+                    best_q = Q
+                    best_phi = PHI
+            
+            assert np.abs(best_p - gpower) < 1e-5
 
     @pytest.mark.parametrize("freq", [1.0])
     @pytest.mark.parametrize("phi_index", [0, 10, -1])
     @pytest.mark.parametrize("q_index", [0, 5, -1])
     @pytest.mark.parametrize("nstreams", [1, 3])
     @pytest.mark.parametrize("freq_batch_size", [1, 3, None])
-    def test_standard(self, freq, q_index, phi_index, nstreams, freq_batch_size):
+    @pytest.mark.parametrize("ignore_negative_delta_sols", [True, False])
+    def test_standard(self, freq, q_index, phi_index, nstreams, freq_batch_size,
+                      ignore_negative_delta_sols):
 
         q_values = np.logspace(-1.5, np.log10(0.1), num=100)
         phi_values = np.linspace(0, 1, int(np.ceil(2./min(q_values))))
@@ -338,9 +308,12 @@ class TestBLS(object):
         power, gsols = eebls_gpu(t, y, dy, freqs,
                                  qmin=0.1 * q, qmax=2.0 * q,
                                  nstreams=nstreams, noverlap=2, dlogq=0.5,
-                                 freq_batch_size=freq_batch_size)
+                                 freq_batch_size=freq_batch_size,
+                                 ignore_negative_delta_sols=ignore_negative_delta_sols)
 
-        bls_c = [single_bls(t, y, dy, x[0], *x[1]) for x in zip(freqs, gsols)]
+        bls_c = [single_bls(t, y, dy, x[0], *x[1],
+                            ignore_negative_delta_sols=ignore_negative_delta_sols)
+                 for x in zip(freqs, gsols)]
         if self.plot:
             import matplotlib.pyplot as plt
             f, ax = plt.subplots()
@@ -378,7 +351,9 @@ class TestBLS(object):
     @pytest.mark.parametrize("phi0", [0.0])
     @pytest.mark.parametrize("use_fast", [True, False])
     @pytest.mark.parametrize("nstreams", [1, 4])
-    def test_transit(self, freq, use_fast, freq_batch_size, nstreams, phi0, dlogq):
+    @pytest.mark.parametrize("ignore_negative_delta_sols", [True, False])
+    def test_transit(self, freq, use_fast, freq_batch_size, nstreams, phi0, dlogq,
+                     ignore_negative_delta_sols):
         q = q_transit(freq)
         samples_per_peak = 2
         noverlap = 2
@@ -388,6 +363,7 @@ class TestBLS(object):
 
         kw = dict(samples_per_peak=samples_per_peak,
                   freq_batch_size=freq_batch_size, dlogq=dlogq,
+                  ignore_negative_delta_sols=ignore_negative_delta_sols,
                   nstreams=nstreams, noverlap=noverlap,
                   fmin=0.9 * freq, fmax=1.1 * freq,
                   use_fast=use_fast)
@@ -397,10 +373,10 @@ class TestBLS(object):
 
             kw['use_fast'] = False
             freqs, power_slow, sols = eebls_transit_gpu(t, y, err, **kw)
-
+            kw['use_fast'] = True
             dfsol = freqs[np.argmax(power)] - freqs[np.argmax(power_slow)]
             close_enough = abs(dfsol) * (max(t) - min(t)) / q < 3
-            if not close_enough:
+            if not close_enough and self.plot:
                 import matplotlib.pyplot as plt
                 plt.plot(freqs, power, alpha=0.5)
                 plt.plot(freqs, power_slow, alpha=0.5)
@@ -410,7 +386,9 @@ class TestBLS(object):
             return
 
         freqs, power, sols = eebls_transit_gpu(t, y, err, **kw)
-        power_cpu = np.array([single_bls(t, y, err, x[0], *x[1]) for x in zip(freqs, sols)])
+        power_cpu = np.array([single_bls(t, y, err, x[0], *x[1],
+                                         ignore_negative_delta_sols=ignore_negative_delta_sols)
+                              for x in zip(freqs, sols)])
 
         if self.plot:
             import matplotlib.pyplot as plt
@@ -438,8 +416,9 @@ class TestBLS(object):
     @pytest.mark.parametrize("dphi", [0.0, 1.0])
     @pytest.mark.parametrize("freq_batch_size", [None, 100])
     @pytest.mark.parametrize("dlogq", [0.5, -1.0])
+    @pytest.mark.parametrize("ignore_negative_delta_sols", [True, False])
     def test_fast_eebls(self, freq, q, phi0, freq_batch_size, dlogq, dphi,
-                        **kwargs):
+                        ignore_negative_delta_sols, **kwargs):
         t, y, err = data(snr=50, q=q, phi0=phi0, freq=freq,
                          baseline=365.)
 
@@ -450,6 +429,7 @@ class TestBLS(object):
         freqs = fmin + df * np.arange(nf)
 
         kw = dict(qmin=1e-2, qmax=0.5, dphi=dphi,
+                  ignore_negative_delta_sols=ignore_negative_delta_sols,
                   freq_batch_size=freq_batch_size, dlogq=dlogq)
 
         kw.update(kwargs)

--- a/cuvarbase/tests/test_bls.py
+++ b/cuvarbase/tests/test_bls.py
@@ -64,7 +64,6 @@ def plot_bls_sol(t, y, dy, freq, q, phi0):
     plt.show()
 
 
-@pytest.fixture
 def data(seed=100, sigma=0.1, ybar=12., snr=10, ndata=200, freq=10.,
          q=0.01, phi0=None, baseline=1.):
 

--- a/cuvarbase/tests/test_ce.py
+++ b/cuvarbase/tests/test_ce.py
@@ -17,7 +17,6 @@ seed = 100
 rand = np.random.RandomState(seed)
 
 
-@pytest.fixture
 def data(sigma=0.1, ndata=500, freq=3., snr=1000, t0=0.):
 
     t = np.sort(rand.rand(ndata)) + t0

--- a/cuvarbase/tests/test_lombscargle.py
+++ b/cuvarbase/tests/test_lombscargle.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from numpy.testing import assert_allclose
-from astropy.stats.lombscargle import LombScargle
+from astropy.timeseries import LombScargle
 
 from ..lombscargle import LombScargleAsyncProcess
 from pycuda.tools import mark_cuda_test
@@ -23,7 +23,6 @@ nfft_sigma = 5
 rand = np.random.RandomState(100)
 
 
-@pytest.fixture
 def data(seed=100, sigma=0.1, ndata=100, freq=3.):
     t = np.sort(rand.rand(ndata))
     y = np.cos(2 * np.pi * freq * t)

--- a/cuvarbase/tests/test_nfft.py
+++ b/cuvarbase/tests/test_nfft.py
@@ -38,7 +38,6 @@ def scale_time(t, samples_per_peak):
     return (t - min(t)) / (samples_per_peak * (max(t) - min(t))) - 0.5
 
 
-@pytest.fixture
 def data(seed=100, sigma=0.1, ndata=100, samples_per_peak=spp):
 
     rand = np.random.RandomState(seed)


### PR DESCRIPTION
This PR adds an option to the BLS functions called `ignore_negative_delta_sols` which will constrain the solution space to only look for actual dips in the data and not consider any solutions where that "dip" is _above_ the mean brightness of the lightcurve.

This restricts the solution space and should help avoid "noisy" solutions (e.g. from systematics) that may overwhelm physical signals in the data. 

I have added unit tests for this;

To illustrate, below is an example:
- One "true" signal at freq = 10, and one "inverted" signal at freq = 23
- The black BLS spectrum is standard BLS
- The red BLS spectrum is BLS with `ignore_negative_delta_sols=True` (note it only picks up the "true" signal)

![bls_no_negative_sols](https://user-images.githubusercontent.com/5678551/170785487-15ca0beb-43c8-404b-9ad0-e69ce50066fd.png)
