### PR TITLE
Swap out pycuda.autoinit for pycuda.autoprimaryctx

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,8 @@
 What's new in cuvarbase
 ***********************
+* **0.2.5**
+    * swap out pycuda.autoinit for pycuda.autoprimaryctx to handle "cuFuncSetBlockShape" error
+    
 * **0.2.4**
     * bugfix for pytest (broke b/c of incorrect fixture usage)
     * added ``ignore_negative_delta_sols`` option to BLS to ignore inverted dips in the lightcurve

--- a/cuvarbase/__init__.py
+++ b/cuvarbase/__init__.py
@@ -1,3 +1,3 @@
-import pycuda.autoinit
-__version__ = "0.2.4"
-
+# import pycuda.autoinit causes problems when running e.g. FFT
+import pycuda.autoprimaryctx
+__version__ = "0.2.5"

--- a/cuvarbase/bls.py
+++ b/cuvarbase/bls.py
@@ -11,7 +11,8 @@ from builtins import zip
 from builtins import range
 import sys
 
-import pycuda.autoinit
+#import pycuda.autoinit
+import pycuda.autoprimaryctx
 import pycuda.driver as cuda
 import pycuda.gpuarray as gpuarray
 from pycuda.compiler import SourceModule
@@ -468,9 +469,9 @@ def eebls_gpu_fast(t, y, dy, freqs, qmin=1e-2, qmax=0.5,
     func = functions[fname]
 
     if shmem_lim is None:
-        dev = pycuda.autoinit.device
+        dev = pycuda.autoprimaryctx.device
         att = cuda.device_attribute.MAX_SHARED_MEMORY_PER_BLOCK
-        shmem_lim = pycuda.autoinit.device.get_attribute(att)
+        shmem_lim = pycuda.autoprimaryctx.device.get_attribute(att)
 
     if memory is None:
         memory = BLSMemory.fromdata(t, y, dy, qmin=qmin, qmax=qmax,

--- a/cuvarbase/ce.py
+++ b/cuvarbase/ce.py
@@ -12,7 +12,8 @@ import numpy as np
 
 import pycuda.driver as cuda
 import pycuda.gpuarray as gpuarray
-import pycuda.autoinit
+#import pycuda.autoinit
+import pycuda.autoprimaryctx
 from pycuda.compiler import SourceModule
 
 from .core import GPUAsyncProcess
@@ -366,9 +367,9 @@ def conditional_entropy_fast(memory, functions, block_size=256,
         ce_logp, ce_std, ce_wt = functions
 
     if shmem_lim is None:
-        dev = pycuda.autoinit.device
+        dev = pycuda.autoprimaryctx.device
         att = cuda.device_attribute.MAX_SHARED_MEMORY_PER_BLOCK
-        shmem_lim = pycuda.autoinit.device.get_attribute(att)
+        shmem_lim = pycuda.autoprimaryctx.device.get_attribute(att)
 
     if transfer_to_device:
         memory.transfer_data_to_gpu()
@@ -843,7 +844,7 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
         the same for each lightcurve. Doesn't reallocate memory for each batch.
 
         .. note::
-            
+
             To get best efficiency, make sure the maximum number of
             observations is not much larger than the typical number
             of observations.

--- a/cuvarbase/tests/test_lombscargle.py
+++ b/cuvarbase/tests/test_lombscargle.py
@@ -13,7 +13,8 @@ from astropy.timeseries import LombScargle
 
 from ..lombscargle import LombScargleAsyncProcess
 from pycuda.tools import mark_cuda_test
-import pycuda.autoinit
+#import pycuda.autoinit
+import pycuda.autoprimaryctx
 spp = 3
 nfac = 3
 lsrtol = 1E-2


### PR DESCRIPTION
@kburdge pointed out that running batched lomb-scargle would fail with "cuFuncSetBlockShape failed: invalid resource handle" error.

Googling brought me here: https://github.com/lebedov/scikit-cuda/issues/330

which suggested to swap out pycuda.autoinit (which creates contexts) with pycuda.autoprimaryctx (which uses the default device context). @kburdge confirmed this appeared to fix the problem.

I cannot run tests to confirm this doesn't cause any other issues!

@astrobatty / @kburdge -- any way you can install this latest version (confirm that it is in fact the latest version) and run pytest to see if our tests still pass with this change?