### PR TITLE
Numpy v2 compatibility

### DIFF
--- a/cuvarbase/ce.py
+++ b/cuvarbase/ce.py
@@ -86,25 +86,20 @@ class ConditionalEntropyMemory(object):
                   alignment=resource.getpagesize())
 
         self.t = cuda.aligned_zeros(shape=(n0,), **kw)
-        self.t = cuda.register_host_memory(self.t)
 
         self.y = cuda.aligned_zeros(shape=(n0,),
                                     dtype=self.ytype,
                                     alignment=resource.getpagesize())
 
-        self.y = cuda.register_host_memory(self.y)
         if self.weighted:
             self.dy = cuda.aligned_zeros(shape=(n0,), **kw)
-            self.dy = cuda.register_host_memory(self.dy)
 
         if self.balanced_magbins:
             self.mag_bwf = cuda.aligned_zeros(shape=(self.mag_bins,), **kw)
-            self.mag_bwf = cuda.register_host_memory(self.mag_bwf)
 
         if self.compute_log_prob:
             self.mag_bin_fracs = cuda.aligned_zeros(shape=(self.mag_bins,),
                                                     **kw)
-            self.mag_bin_fracs = cuda.register_host_memory(self.mag_bin_fracs)
         return self
 
     def allocate_pinned_cpu(self, **kwargs):
@@ -113,7 +108,6 @@ class ConditionalEntropyMemory(object):
 
         self.ce_c = cuda.aligned_zeros(shape=(nf,), dtype=self.real_type,
                                        alignment=resource.getpagesize())
-        self.ce_c = cuda.register_host_memory(self.ce_c)
 
         return self
 

--- a/cuvarbase/cunfft.py
+++ b/cuvarbase/cunfft.py
@@ -98,7 +98,6 @@ class NFFTMemory(object):
         self.ghat_c = cuda.aligned_zeros(shape=(self.nf,),
                                          dtype=self.complex_type,
                                          alignment=resource.getpagesize())
-        self.ghat_c = cuda.register_host_memory(self.ghat_c)
 
         return self
 

--- a/cuvarbase/lombscargle.py
+++ b/cuvarbase/lombscargle.py
@@ -187,7 +187,6 @@ class LombScargleMemory(object):
 
         self.lsp_c = cuda.aligned_zeros(shape=(nf,), dtype=self.real_type,
                                         alignment=resource.getpagesize())
-        self.lsp_c = cuda.register_host_memory(self.lsp_c)
 
         return self
 
@@ -208,17 +207,15 @@ class LombScargleMemory(object):
         self.t = cuda.aligned_zeros(shape=(n0,),
                                     dtype=self.real_type,
                                     alignment=resource.getpagesize())
-        self.t = cuda.register_host_memory(self.t)
 
         self.yw = cuda.aligned_zeros(shape=(n0,),
                                      dtype=self.real_type,
                                      alignment=resource.getpagesize())
-        self.yw = cuda.register_host_memory(self.yw)
 
         self.w = cuda.aligned_zeros(shape=(n0,),
                                     dtype=self.real_type,
                                     alignment=resource.getpagesize())
-        self.w = cuda.register_host_memory(self.w)
+
         return self
 
     def allocate(self, **kwargs):

--- a/cuvarbase/pdm.py
+++ b/cuvarbase/pdm.py
@@ -161,8 +161,6 @@ class PDMAsyncProcess(GPUAsyncProcess):
 
     def __init__(self, *args, **kwargs):
         super(PDMAsyncProcess, self).__init__(*args, **kwargs)
-        warnings.warn("PDM is experimental at this point. "
-                      "Use with great caution.")
 
     def _compile_and_prepare_functions(self, nbins=10):
         pdm2_txt = open(find_kernel('pdm'), 'r').read()

--- a/cuvarbase/pdm.py
+++ b/cuvarbase/pdm.py
@@ -192,8 +192,6 @@ class PDMAsyncProcess(GPUAsyncProcess):
                                          dtype=np.float32,
                                          alignment=resource.getpagesize())
 
-            pow_cpu = cuda.register_host_memory(pow_cpu)
-
             t_g, y_g, w_g = None, None, None
             if len(t) > 0:
                 t_g, y_g, w_g = tuple([gpuarray.zeros(len(t), dtype=np.float32)

--- a/cuvarbase/tests/test_nfft.py
+++ b/cuvarbase/tests/test_nfft.py
@@ -75,7 +75,7 @@ def gpu_grid_scalar(t, y, sigma, m, N):
 
     q1, q2, q3 = precomp_psi(t, b, n, m)
 
-    u = (np.floor(n * (t + 0.5) - m)).astype(np.int)
+    u = (np.floor(n * (t + 0.5) - m)).astype(int)
 
     grid = np.zeros(n)
 

--- a/cuvarbase/utils.py
+++ b/cuvarbase/utils.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import pkg_resources
+from importlib.resources import files
 
 
 def weights(err):
@@ -13,8 +13,7 @@ def weights(err):
 
 
 def find_kernel(name):
-    return pkg_resources.resource_filename('cuvarbase',
-                                           'kernels/%s.cu' % (name))
+    return files("cuvarbase").joinpath('kernels', f'{name}.cu')
 
 
 def _module_reader(fname, cpp_defs=None):

--- a/cuvarbase/utils.py
+++ b/cuvarbase/utils.py
@@ -13,7 +13,7 @@ def weights(err):
 
 
 def find_kernel(name):
-    return files("cuvarbase").joinpath('kernels', f'{name}.cu')
+    return str(files("cuvarbase").joinpath('kernels', f'{name}.cu'))
 
 
 def _module_reader(fname, cpp_defs=None):

--- a/docs/source/plots/benchmarks.py
+++ b/docs/source/plots/benchmarks.py
@@ -16,7 +16,7 @@ import cuvarbase.bls as bls
 import cuvarbase.ce as ce
 import cuvarbase.lombscargle as ls
 from astrobase.periodbase.kbls import _bls_runner as astrobase_bls
-from astropy.stats.lombscargle import LombScargle as AstropyLombScargle
+from astropy.timeseries import LombScargle as AstropyLombScargle
 from tqdm import tqdm
 
 

--- a/notebooks/Lomb Scargle.ipynb
+++ b/notebooks/Lomb Scargle.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "from astropy.stats.lombscargle import LombScargle\n",
+    "from astropy.timeseries import LombScargle\n",
     "\n",
     "def data(ndata=100, freq=0.1, y0=10., amp=0.05, sigma=0.01, baseline=365., seed=100):\n",
     "    rand = np.random.RandomState(seed)\n",
@@ -174,7 +174,7 @@
     "axlsp.legend(loc='best')\n",
     "plt.show()\n",
     "\n",
-    "print \"False alarm probability: \", fap_baluev(t, dy, max(powers), max(freqs))"
+    "print(\"False alarm probability: \", fap_baluev(t, dy, max(powers), max(freqs)))"
    ]
   },
   {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,9 @@
+-e .
 future
 numpy >= 1.6
 scipy
 pycuda >= 2017.1.1, != 2024.1.2
 scikit-cuda
+pytest
+nfft
+astropy


### PR DESCRIPTION
This PR introduces updates to make cuvarbase compatible with numpy v2 and the latest pycuda. Also added some minor fixes/updates.