### PR TITLE
Normalize light curves before calling LS or PDM

### DIFF
--- a/cuvarbase/lombscargle.py
+++ b/cuvarbase/lombscargle.py
@@ -17,7 +17,7 @@ from pycuda.compiler import SourceModule
 # import pycuda.autoinit
 
 from .core import GPUAsyncProcess
-from .utils import weights, find_kernel, _module_reader
+from .utils import weights, find_kernel, _module_reader, normalize_light_curves
 from .utils import autofrequency as utils_autofreq
 from .cunfft import NFFTAsyncProcess, nfft_adjoint_async, NFFTMemory
 
@@ -966,6 +966,9 @@ class LombScargleAsyncProcess(GPUAsyncProcess):
                      ['lomb', 'lomb_dirsum']]):
             self._compile_and_prepare_functions(**kwargs)
 
+        # Prepare data
+        data = normalize_light_curves(data)
+
         # create and/or check frequencies
         frqs = freqs
         if frqs is None:
@@ -1026,6 +1029,9 @@ class LombScargleAsyncProcess(GPUAsyncProcess):
             not all([func in self.prepared_functions for func in
                      ['lomb', 'lomb_dirsum']]):
             self._compile_and_prepare_functions(**kwargs)
+
+        # Prepare data
+        data = normalize_light_curves(data)
 
         # create streams if needed
         bsize = min([len(data), batch_size])

--- a/cuvarbase/pdm.py
+++ b/cuvarbase/pdm.py
@@ -15,7 +15,8 @@ from pycuda.compiler import SourceModule
 # import pycuda.autoinit
 
 from .core import GPUAsyncProcess
-from .utils import weights, find_kernel, dphase
+from .utils import weights, find_kernel, dphase, normalize_light_curves
+
 
 def var_tophat(t, y, w, freq, dphi):
     var = 0.
@@ -217,11 +218,7 @@ class PDMAsyncProcess(GPUAsyncProcess):
             self._compile_and_prepare_functions(nbins=nbins)
 
         # Prepare data
-        for i,(t, y, w, freqs) in enumerate(data):
-            t, y, w, freqs = t.copy(), y.copy(), w.copy(), freqs.copy()
-            t -= np.mean(t)
-            y -= np.mean(y)
-            data[i] = t, y, w, freqs
+        data = normalize_light_curves(data)
 
         if pow_cpus is None or gpu_data is None:
             gpu_data, pow_cpus = self.allocate(data)

--- a/cuvarbase/utils.py
+++ b/cuvarbase/utils.py
@@ -107,3 +107,36 @@ def get_autofreqs(t, **kwargs):
                         if var in ['minimum_frequency', 'maximum_frequency',
                                    'nyquist_factor', 'samples_per_peak']}
     return autofrequency(t, **autofreqs_kwargs)
+
+
+def normalize_light_curves(data: list[tuple[np.array, ...]]):
+    """
+    Normalize light curves by subtracting the mean from the magnitudes and the observation times.
+
+    Parameters
+    ----------
+    data: list of tuples
+        list of [(t, y, ...), ...] containing
+        * ``t``: observation times
+        * ``y``: observations
+        * ... other columns
+
+    Returns
+    -------
+    data: list of tuples
+        list of [(t, y, dy), ...] containing
+        * ``t``: updated observation times
+        * ``y``: updated observations
+        * ... other columns
+
+    """
+    for i, lc in enumerate(data):
+        updated_lc = []
+        for j in range(len(lc)):
+            if j < 2:
+                updated_lc.append((lc[j] - np.nanmean(lc[j])).copy())
+            else:
+                updated_lc.append(lc[j].copy())
+        data[i] = tuple(updated_lc)
+
+    return data


### PR DESCRIPTION
Introduced a new normalize_light_curves function in utils.py to standardize light curve data by subtracting the mean from observation times and magnitudes. Updated LombScargleAsyncProcess and PDMAsyncProcess to use this normalization step, which is needed to calculate a proper spectrum.

I'm not sure, but other methods may also require this patch.