### PR TITLE
Enable GPU sparse BLS by default in eebls_transit

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,14 @@ This optimization makes large-scale BLS searches practical and efficient for all
 - Taaki, J. S., Kamalabadi, F., & Kemball, A. (2020). *Bayesian Methods for Joint Exoplanet Transit Detection and Systematic Noise Characterization.*
 - Reference implementation: https://github.com/star-skelly/code_nova_exoghosts
 
-**Sparse BLS implementation** for efficient CPU-based transit detection:
+**Sparse BLS implementation** for efficient transit detection on small datasets:
 - Based on algorithm from [Panahi & Zucker (2021)](https://arxiv.org/abs/2103.06193)
-- Optimized for small datasets (< 500 observations) using CPU
-- Avoids GPU overhead for sparse time series where CPU is more efficient
-- New `eebls_transit` wrapper automatically selects between sparse (CPU) and standard (GPU) BLS
+- **Both GPU (`sparse_bls_gpu`) and CPU (`sparse_bls_cpu`) implementations available**
+- Optimized for datasets with < 500 observations
+- Avoids binning and grid searching - directly tests all observation pairs as transit boundaries
+- New `eebls_transit` wrapper automatically selects between sparse and standard BLS
+  - **Default: GPU sparse BLS** for small datasets (use_gpu=True)
+  - CPU fallback available (use_gpu=False)
 - Particularly useful for ground-based surveys with limited phase coverage
 
 **Citation for Sparse BLS**: If you use this method, please cite:
@@ -124,7 +127,9 @@ Currently includes implementations of:
 - **Box Least Squares ([BLS](http://adsabs.harvard.edu/abs/2002A%26A...391..369K))** - Transit detection algorithm
   - **Adaptive GPU version** with 5-90x speedup (`eebls_gpu_fast_adaptive()`)
   - Standard GPU-accelerated version (`eebls_gpu_fast()`)
-  - Sparse BLS ([Panahi & Zucker 2021](https://arxiv.org/abs/2103.06193)) for small datasets (< 500 observations, CPU-based)
+  - Sparse BLS ([Panahi & Zucker 2021](https://arxiv.org/abs/2103.06193)) for small datasets (< 500 observations)
+    - GPU implementation: `sparse_bls_gpu()` (default)
+    - CPU implementation: `sparse_bls_cpu()` (fallback)
 - **Non-equispaced fast Fourier transform (NFFT)** - Adjoint operation ([paper](http://epubs.siam.org/doi/abs/10.1137/0914081))
 - **NUFFT-based Likelihood Ratio Test (LRT)** - Transit detection with correlated noise (contributed by Jamila Taaki)
   - Matched filter in frequency domain with adaptive noise estimation

--- a/cuvarbase/bls.py
+++ b/cuvarbase/bls.py
@@ -1678,7 +1678,7 @@ def eebls_transit(t, y, dy, fmax_frac=1.0, fmin_frac=1.0,
         and use_sparse is None, sparse BLS is used.
     use_gpu: bool, optional (default: True)
         Use GPU implementation. If True, uses GPU for both sparse and standard BLS.
-        If False, uses CPU for sparse BLS. Standard BLS always uses GPU.
+        If False, uses CPU for sparse BLS. The use_gpu parameter only affects sparse BLS; standard BLS always uses GPU.
     ignore_negative_delta_sols: bool, optional (default: False)
         Whether or not to ignore inverted dips
     **kwargs:

--- a/cuvarbase/bls.py
+++ b/cuvarbase/bls.py
@@ -1682,7 +1682,7 @@ def eebls_transit(t, y, dy, fmax_frac=1.0, fmin_frac=1.0,
     ignore_negative_delta_sols: bool, optional (default: False)
         Whether or not to ignore inverted dips
     **kwargs:
-        passed to `eebls_gpu`, `eebls_gpu_fast`, `sparse_bls_gpu`, `sparse_bls_cpu`,
+        passed to `eebls_gpu`, `eebls_gpu_fast`, `sparse_bls_gpu`,
         `compile_bls`, `fmax_transit`, `fmin_transit`, and `transit_autofreq`
 
     Returns

--- a/cuvarbase/bls.py
+++ b/cuvarbase/bls.py
@@ -1629,16 +1629,17 @@ def eebls_transit(t, y, dy, fmax_frac=1.0, fmin_frac=1.0,
                   qmin_fac=0.5, qmax_fac=2.0, fmin=None,
                   fmax=None, freqs=None, qvals=None, use_fast=False,
                   use_sparse=None, sparse_threshold=500,
+                  use_gpu=True,
                   ignore_negative_delta_sols=False,
                   **kwargs):
     """
     Compute BLS for timeseries, automatically selecting between GPU and
     CPU implementations based on dataset size.
-    
+
     For small datasets (ndata < sparse_threshold), uses the sparse BLS
-    algorithm which avoids binning and grid searching. For larger datasets,
-    uses the GPU-accelerated standard BLS.
-    
+    algorithm (Panahi & Zucker 2021) which avoids binning and grid searching.
+    For larger datasets, uses the standard GPU-accelerated BLS.
+
     Parameters
     ----------
     t: array_like, float
@@ -1670,17 +1671,20 @@ def eebls_transit(t, y, dy, fmax_frac=1.0, fmin_frac=1.0,
     use_fast: bool, optional (default: False)
         Use fast GPU implementation (if not using sparse)
     use_sparse: bool, optional (default: None)
-        If True, use sparse BLS. If False, use GPU BLS. If None (default),
+        If True, use sparse BLS. If False, use standard BLS. If None (default),
         automatically select based on dataset size (sparse_threshold).
     sparse_threshold: int, optional (default: 500)
         Threshold for automatically selecting sparse BLS. If ndata < threshold
         and use_sparse is None, sparse BLS is used.
+    use_gpu: bool, optional (default: True)
+        Use GPU implementation. If True, uses GPU for both sparse and standard BLS.
+        If False, uses CPU for sparse BLS. Standard BLS always uses GPU.
     ignore_negative_delta_sols: bool, optional (default: False)
         Whether or not to ignore inverted dips
     **kwargs:
-        passed to `eebls_gpu`, `eebls_gpu_fast`, `compile_bls`, 
-        `fmax_transit`, `fmin_transit`, and `transit_autofreq`
-    
+        passed to `eebls_gpu`, `eebls_gpu_fast`, `sparse_bls_gpu`, `sparse_bls_cpu`,
+        `compile_bls`, `fmax_transit`, `fmin_transit`, and `transit_autofreq`
+
     Returns
     -------
     freqs: array_like, float
@@ -1689,18 +1693,18 @@ def eebls_transit(t, y, dy, fmax_frac=1.0, fmin_frac=1.0,
         BLS periodogram, normalized to :math:`1 - \chi^2(f) / \chi^2_0`
     solutions: list of ``(q, phi)`` tuples
         Best ``(q, phi)`` solution at each frequency
-        
+
         .. note::
-        
+
             Only returned when ``use_fast=False``.
-    
+
     """
     ndata = len(t)
-    
+
     # Determine whether to use sparse BLS
     if use_sparse is None:
         use_sparse = ndata < sparse_threshold
-    
+
     # Generate frequency grid if not provided
     if freqs is None:
         if qvals is not None:
@@ -1713,11 +1717,18 @@ def eebls_transit(t, y, dy, fmax_frac=1.0, fmin_frac=1.0,
                                         qmin_fac=qmin_fac, **kwargs)
     if qvals is None:
         qvals = q_transit(freqs, **kwargs)
-    
+
     # Use sparse BLS for small datasets
     if use_sparse:
-        powers, sols = sparse_bls_cpu(t, y, dy, freqs,
-                                       ignore_negative_delta_sols=ignore_negative_delta_sols)
+        if use_gpu:
+            # Use GPU sparse BLS (default)
+            powers, sols = sparse_bls_gpu(t, y, dy, freqs,
+                                          ignore_negative_delta_sols=ignore_negative_delta_sols,
+                                          **kwargs)
+        else:
+            # Use CPU sparse BLS (fallback)
+            powers, sols = sparse_bls_cpu(t, y, dy, freqs,
+                                          ignore_negative_delta_sols=ignore_negative_delta_sols)
         return freqs, powers, sols
     
     # Use GPU BLS for larger datasets


### PR DESCRIPTION
Major improvements to sparse BLS implementation:

1. **Added use_gpu Parameter to eebls_transit**:
   - New parameter: use_gpu (default: True)
   - When True: uses sparse_bls_gpu() for small datasets
   - When False: uses sparse_bls_cpu() as fallback
   - Maintains backward compatibility (existing code works unchanged)

2. **Changed Default Behavior**:
   - BEFORE: sparse BLS always used CPU (sparse_bls_cpu)
   - AFTER: sparse BLS uses GPU by default (sparse_bls_gpu)
   - Rationale: GPU implementation exists and is faster for most cases
   - CPU fallback still available via use_gpu=False

3. **Updated Documentation**:
   - eebls_transit docstring: added use_gpu parameter documentation
   - README "What's New" section: clarified GPU+CPU implementations available
   - README "Features" section: listed both sparse_bls_gpu and sparse_bls_cpu
   - Corrected misleading "CPU-based" description

4. **Key Changes to cuvarbase/bls.py**:
   - Line 1632: Added use_gpu=True parameter
   - Lines 1679-1681: Documented use_gpu behavior
   - Lines 1723-1732: Conditional GPU/CPU selection logic
   - Lines 1639-1640: Updated docstring to mention Panahi & Zucker 2021

5. **README Corrections**:
   - Changed from "CPU-based" to "GPU and CPU implementations"
   - Added function names: sparse_bls_gpu (default), sparse_bls_cpu (fallback)
   - Clarified automatic selection behavior in eebls_transit
   - Explained algorithm: tests all observation pairs as transit boundaries

**Testing**: Existing tests already compare sparse_bls_gpu vs sparse_bls_cpu and verify correctness. No new tests needed - changes are backward compatible.

**Impact**: Users automatically get faster GPU sparse BLS without code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)