### PR TITLE
Use setuptools.packages.find to include packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ Documentation = "https://johnh2o2.github.io/cuvarbase/"
 Repository = "https://github.com/johnh2o2/cuvarbase"
 "Bug Tracker" = "https://github.com/johnh2o2/cuvarbase/issues"
 
-[tool.setuptools]
-packages = ["cuvarbase", "cuvarbase.tests"]
+[tool.setuptools.packages.find]
+include = ["cuvarbase*"]
 
 [tool.setuptools.package-data]
 cuvarbase = ["kernels/*.cu"]


### PR DESCRIPTION
Replace explicit packages list with setuptools' package finder to automatically include all cuvarbase subpackages. Use include = ["cuvarbase*"] to match the package and its subpackages, simplifying packaging and maintenance. Package-data entries remain unchanged.