### PR TITLE
Remove inline normalization in LombScargleAsyncProcess

### DIFF
--- a/cuvarbase/lombscargle.py
+++ b/cuvarbase/lombscargle.py
@@ -728,9 +728,6 @@ class LombScargleAsyncProcess(GPUAsyncProcess):
                      ['lomb', 'lomb_dirsum']]):
             self._compile_and_prepare_functions(**kwargs)
 
-        # Prepare data
-        data = normalize_light_curves(data)
-
         # create streams if needed
         bsize = min([len(data), batch_size])
         if len(self.streams) < bsize:


### PR DESCRIPTION
Normalization is handled by `self.run`. This PR removes redundant code.