### PR TITLE
Conditional Entropy enhancements and bug fixes

### DIFF
--- a/cuvarbase/ce.py
+++ b/cuvarbase/ce.py
@@ -544,6 +544,12 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
 
         cpers = []
         for d, f in zip(data, frqs):
+            # Limit frequencies to ensure that
+            # thread numbers are within the limits of single-precision
+            max_threads_per_launch = 2**32 - 1
+            total_threads = len(d[0]) * len(f)
+            thread_nbatches = int(np.ceil(total_threads/max_threads_per_launch))
+
             size_of_real = self.real_type(1).nbytes
 
             # subtract of lc memory
@@ -552,6 +558,10 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
             tot_bins = self.phase_bins * self.mag_bins
             batch_size = int(np.floor(fmem / (size_of_real * (tot_bins + 2))))
             nbatches = int(np.ceil(len(f) / float(batch_size)))
+
+            if thread_nbatches > nbatches:
+                nbatches = thread_nbatches
+                batch_size = int(np.ceil(len(f) / float(nbatches)))
 
             cper = np.zeros(len(f))
             for i in range(nbatches):

--- a/cuvarbase/ce.py
+++ b/cuvarbase/ce.py
@@ -228,6 +228,8 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
         if kwargs.get('use_fast', False):
             self.call_func = conditional_entropy_fast
 
+        self.use_fast = kwargs.get('use_fast', False)
+
         self.memory = kwargs.get('memory', None)
         self.shmem_lc = kwargs.get('shmem_lc', True)
 
@@ -469,6 +471,13 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
             frqs = [frqs] * len(data)
 
         assert(len(frqs) == len(data))
+
+        if not self.use_fast:
+            for f, d in zip(frqs, data):
+                if len(f) * len(d[0]) > 2**32-1:
+                    raise OverflowError(
+                        "Number of streams is too large - overflowing 32 bit integers\n"
+                        "Decrease frequency range or use :func:`large_run` instead")
 
         memory = memory if memory is not None else self.memory
 

--- a/cuvarbase/ce.py
+++ b/cuvarbase/ce.py
@@ -182,6 +182,8 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
         computations. This is perfect for large Nfreqs and nobs <~ 2000.
         If True, use :func:`run` and not :func:`large_run` and set
         ``nstreams = 1``.
+    compute_log_prob: bool, optional (default: False)
+        Instead of computing CE, compute and return the log-probability periodogram.
 
     Example
     -------
@@ -203,6 +205,7 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
         self.max_phi = kwargs.get('max_phi', 3.)
         self.weighted = kwargs.get('weighted', False)
         self.block_size = kwargs.get('block_size', 256)
+        self.compute_log_prob = kwargs.get('compute_log_prob', False)
 
         self.phase_overlap = kwargs.get('phase_overlap', 0)
         self.mag_overlap = kwargs.get('mag_overlap', 0)
@@ -309,7 +312,8 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
                   max_phi=self.max_phi,
                   stream=stream,
                   weighted=self.weighted,
-                  use_double=self.use_double)
+                  use_double=self.use_double,
+                  compute_log_prob=self.compute_log_prob)
 
         kw.update(kwargs)
         mem = ConditionalEntropyMemory(**kw)
@@ -397,6 +401,7 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
                   max_phi=self.max_phi,
                   weighted=self.weighted,
                   use_double=self.use_double,
+                  compute_log_prob=self.compute_log_prob,
                   n0_buffer=max_nobs,
                   buffered_transfer=True,
                   allocate=True,
@@ -611,7 +616,8 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
                           mag_bins=self.mag_bins,
                           weighted=self.weighted,
                           max_phi=self.max_phi,
-                          use_double=self.use_double)
+                          use_double=self.use_double,
+                          compute_log_prob=self.compute_log_prob)
         kwargs_mem.update(kwargs)
         memory = [ConditionalEntropyMemory(stream=stream, **kwargs_mem)
                   for stream in streams]

--- a/cuvarbase/ce.py
+++ b/cuvarbase/ce.py
@@ -602,7 +602,7 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
 
         if freqs is None:
             data_with_max_baseline = max(data,
-                                         key=lambda d: max(d[0]) - min(d[0]))
+                                         key=lambda d: np.max(d[0]) - np.min(d[0]))
             freqs = self.autofrequency(data_with_max_baseline[0], **kwargs)
 
         df = freqs[1] - freqs[0]

--- a/cuvarbase/ce.py
+++ b/cuvarbase/ce.py
@@ -212,6 +212,9 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
                 raise Exception("mag_overlap must be zero "
                                 "if balanced_magbins is True")
 
+        if self.weighted and kwargs.get('use_fast', False):
+            raise Exception("use_fast must be False if weighted is True")
+
         self.use_double = kwargs.get('use_double', False)
 
         self.real_type = np.float32

--- a/cuvarbase/ce.py
+++ b/cuvarbase/ce.py
@@ -187,7 +187,7 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
     -------
     >>> proc = ConditionalEntropyAsyncProcess()
     >>> Ndata = 1000
-    >>> t = np.sort(365 * np.random.rand(N))
+    >>> t = np.sort(365 * np.random.rand(Ndata))
     >>> y = 12 + 0.01 * np.cos(2 * np.pi * t / 5.0)
     >>> y += 0.01 * np.random.randn(len(t))
     >>> dy = 0.01 * np.ones_like(y)

--- a/cuvarbase/ce.py
+++ b/cuvarbase/ce.py
@@ -11,7 +11,7 @@ import pycuda.autoprimaryctx
 from pycuda.compiler import SourceModule
 
 from .core import GPUAsyncProcess
-from .utils import _module_reader, find_kernel
+from .utils import _module_reader, find_kernel, normalize_light_curves
 from .utils import autofrequency as utils_autofreq
 from .memory import ConditionalEntropyMemory
 
@@ -451,6 +451,9 @@ class ConditionalEntropyAsyncProcess(GPUAsyncProcess):
             not all([func in self.prepared_functions for func in
                      ['ce_wt']]):
             self._compile_and_prepare_functions(**kwargs)
+
+        # Prepare data
+        data = normalize_light_curves(data)
 
         # create and/or check frequencies
         frqs = freqs

--- a/cuvarbase/lombscargle.py
+++ b/cuvarbase/lombscargle.py
@@ -741,14 +741,14 @@ class LombScargleAsyncProcess(GPUAsyncProcess):
 
         if freqs is None:
             data_with_max_baseline = max(data,
-                                         key=lambda d: max(d[0]) - min(d[0]))
+                                         key=lambda d: np.max(d[0]) - np.min(d[0]))
             freqs = self.autofrequency(data_with_max_baseline[0], **kwargs)
 
             # now correct frequencies
             df = freqs[1] - freqs[0]
             k0 = get_k0(freqs)
             # nf = len(freqs)
-            nf = int(round(max(freqs) / df)) - k0
+            nf = int(round(np.max(freqs) / df)) - k0
             freqs = df * (k0 + np.arange(nf))
 
         df = freqs[1] - freqs[0]


### PR DESCRIPTION
Bug fixes:
 - typo in example
 - raise error when mixing fast and weighted methods
 - normalize light curves before processing to avoid 32bit overflow errors

Enhancements:
- allow the usage of already implemented `compute_log_prob` in ConditionalEntropy
- update `large_run()` to ensure that thread numbers are within the limits of single-precision
- use `numpy` to get min/max for efficiency
- disallow large runs in `run()`, warn users to use `large_run()` instead